### PR TITLE
On qa- have added a model for capturing measurement data for CPU

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -6,6 +6,7 @@
         <option name="distributionType" value="LOCAL" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleHome" value="$APPLICATION_HOME_DIR$/gradle/gradle-2.2.1" />
+        <option name="gradleJvm" value="1.7" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
@@ -16,4 +17,3 @@
     </option>
   </component>
 </project>
-

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,8 +3,7 @@
   <component name="EntryPointsManager">
     <entry_points version="2.0" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" assert-keyword="true" jdk-15="true" project-jdk-name="1.7" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
 </project>
-

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,9 +2,8 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/Benchmark-example.iml" filepath="$PROJECT_DIR$/Benchmark-example.iml" />
+      <module fileurl="file://$PROJECT_DIR$/MY-Ara-MicroBench.iml" filepath="$PROJECT_DIR$/MY-Ara-MicroBench.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
     </modules>
   </component>
 </project>
-

--- a/MY-Ara-MicroBench.iml
+++ b/MY-Ara-MicroBench.iml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="MY-Ara-MicroBench" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="java-gradle" name="Java-Gradle">
       <configuration>
         <option name="BUILD_FOLDER_PATH" value="$MODULE_DIR$/build" />
+        <option name="BUILDABLE" value="false" />
       </configuration>
     </facet>
   </component>
@@ -16,4 +17,3 @@
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>
-

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Ara-MicroBench
+Making a Micro Regulated Benchmark for the Ara project.
+QA work

--- a/app/app.iml
+++ b/app/app.iml
@@ -82,6 +82,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 21 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/app/app.iml
+++ b/app/app.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="Benchmark-example" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":app" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="MY-Ara-MicroBench" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>
@@ -12,8 +12,9 @@
         <option name="SELECTED_TEST_ARTIFACT" value="_android_test_" />
         <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
         <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
-        <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleDebugAndroidTest" />
         <option name="SOURCE_GEN_TASK_NAME" value="generateDebugSources" />
+        <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleDebugAndroidTest" />
+        <option name="COMPILE_JAVA_TEST_TASK_NAME" value="compileDebugAndroidTestSources" />
         <option name="TEST_SOURCE_GEN_TASK_NAME" value="generateDebugAndroidTestSources" />
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
@@ -81,7 +82,6 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 21 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
@@ -90,4 +90,3 @@
     <orderEntry type="library" exported="" name="support-v4-21.0.3" level="project" />
   </component>
 </module>
-

--- a/app/src/main/java/com/example/xaradrim/benchmark_example/MainActivity.java
+++ b/app/src/main/java/com/example/xaradrim/benchmark_example/MainActivity.java
@@ -39,7 +39,7 @@ public class MainActivity extends ActionBarActivity {
 //        } else {
             t = new Test();
             System.out.println("Observer attached");
-          //  new ObserverCPU(t,"ProjectARA-CPU");
+            new ObserverCPU(t,"ProjectARA-CPU");
 
 //        }
     }

--- a/app/src/main/java/com/example/xaradrim/benchmark_example/MainActivity.java
+++ b/app/src/main/java/com/example/xaradrim/benchmark_example/MainActivity.java
@@ -79,24 +79,24 @@ public class MainActivity extends ActionBarActivity {
 
         // this is to selecting and running the actual test
 
-        System.out.println("clicked");
+        //System.out.println("clicked");
         if (B.isChecked()) {
 
 
             if (((CheckBox) findViewById(R.id.cpu_box)).isChecked()) {
 
-                System.out.println("Im starting the cpu test");
+                //System.out.println("Im starting the cpu test");
                 t.add_test(t.make_test("cpu"));
 
 
             }
             if (((CheckBox) findViewById(R.id.memory_box)).isChecked()) {
-                System.out.println("Im starting the memory test");
+                //System.out.println("Im starting the memory test");
                 t.add_test(t.make_test("memory"));
 
             }
 
-            System.out.println("Test Started.");
+            //System.out.println("Test Started.");
             t.start_test();
 
 

--- a/app/src/main/java/com/example/xaradrim/benchmark_example/MainActivity.java
+++ b/app/src/main/java/com/example/xaradrim/benchmark_example/MainActivity.java
@@ -39,7 +39,7 @@ public class MainActivity extends ActionBarActivity {
 //        } else {
             t = new Test();
             System.out.println("Observer attached");
-            new ObserverCPU(t,"ProjectARA-CPU");
+          //  new ObserverCPU(t,"ProjectARA-CPU");
 
 //        }
     }

--- a/app/src/main/java/com/example/xaradrim/benchmark_example/MainActivity.java
+++ b/app/src/main/java/com/example/xaradrim/benchmark_example/MainActivity.java
@@ -1,5 +1,10 @@
 package com.example.xaradrim.benchmark_example;
 
+import android.app.Activity;
+import android.app.ActivityManager;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
 import android.support.v7.app.ActionBarActivity;
 import android.os.Bundle;
 import android.view.Menu;
@@ -7,23 +12,36 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
 import android.widget.CheckBox;
+import android.widget.LinearLayout;
+import android.widget.TextView;
 import android.widget.ToggleButton;
 
+import com.example.xaradrim.benchmark_example.Tests.ObserverCPU;
 import com.example.xaradrim.benchmark_example.Tests.Test;
 import com.example.xaradrim.benchmark_example.Tests.Testable;
+
+import java.util.List;
 
 public class MainActivity extends ActionBarActivity {
 
     private Test t = null;
-
+    private TextView myText = null;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        t = new Test();
+//        if (isProcessRunning("com.eembc.andebench")) {
+//            Intent launchIntent = getPackageManager().getLaunchIntentForPackage("com.eembc.andebench");
+//            startActivity(launchIntent);
+//
+//        } else {
+            t = new Test();
+            System.out.println("Observer attached");
+            new ObserverCPU(t,"ProjectARA-CPU");
 
+//        }
     }
 
 
@@ -60,35 +78,55 @@ public class MainActivity extends ActionBarActivity {
 
         // this is to selecting and running the actual test
 
-
+        System.out.println("clicked");
         if (B.isChecked()) {
-
 
 
             if (((CheckBox) findViewById(R.id.cpu_box)).isChecked()) {
 
-                //System.out.println("Im starting the cpu test");
+                System.out.println("Im starting the cpu test");
                 t.add_test(t.make_test("cpu"));
+
 
             }
             if (((CheckBox) findViewById(R.id.memory_box)).isChecked()) {
+                System.out.println("Im starting the memory test");
                 t.add_test(t.make_test("memory"));
 
             }
 
+            System.out.println("Test Started.");
             t.start_test();
 
 
+        } else {
 
+            t.halt_execution();
 
         }
-
-        else
-            {
-
-                t.halt_execution();
-
-            }
     }
 
+    //listing other benchmark app running in bakcground, if any.
+    void listingOB() {
+        if (isProcessRunning("com.example.xaradrim.benchmark_example")) {
+            System.out.println(" only Project ara is running? -> " );
+        } else {
+            System.out.println("AndEbenc is running> ->" + isProcessRunning("com.eembc.andebench"));
+        }
+
+    }
+
+    boolean isProcessRunning(String processName) {
+        if (processName == null)
+            return false;
+
+        ActivityManager manager = (ActivityManager) this.getSystemService(Activity.ACTIVITY_SERVICE);
+        List<ActivityManager.RunningAppProcessInfo> processes = manager.getRunningAppProcesses();
+        for (ActivityManager.RunningAppProcessInfo process : processes) {
+            if (processName.equals(process.processName)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/app/src/main/java/com/example/xaradrim/benchmark_example/MainActivity.java
+++ b/app/src/main/java/com/example/xaradrim/benchmark_example/MainActivity.java
@@ -38,6 +38,7 @@ public class MainActivity extends ActionBarActivity {
 //
 //        } else {
             t = new Test();
+        //code added : Pardeep
             System.out.println("Observer attached");
             new ObserverCPU(t,"ProjectARA-CPU");
 
@@ -105,7 +106,7 @@ public class MainActivity extends ActionBarActivity {
 
         }
     }
-
+    //Code added : Pardeep
     //listing other benchmark app running in bakcground, if any.
     void listingOB() {
         if (isProcessRunning("com.example.xaradrim.benchmark_example")) {

--- a/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/Cpu.java
+++ b/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/Cpu.java
@@ -12,22 +12,21 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 /**
  * Created by xaradrim on 5/29/15.
- * updated by pdp on 26-Jun
+ * * updated by pdp on 26-Jun
  */
 public class Cpu  implements Testable {
     private boolean Testing;
 
-    // File initiators.
+    // File
     FileWriter fw;
     BufferedWriter bw;
     File file;
     int count=0;
+    float volt=0,curr=0,power=0;
+    boolean isVolt = true;
     Cpu(){
-
-        //appending timestamp in the file name
         long unixTime = System.currentTimeMillis() / 1000L;
-        //file save at this location
-        String fpath = "/sdcard/charsticks/" + "CPU-charLog" +unixTime+ ".txt";
+        String fpath = "/sdcard/charsticks/" + "CPU-charLog"+".txt";
 
 
         file= new File(fpath);
@@ -63,19 +62,26 @@ public class Cpu  implements Testable {
             String s = null;
             try{
 
-                //running ADB commands; Writing to the file in /sdcard/
+
                 Process process = Runtime.getRuntime().exec("cat /sys/class/power_supply/battery/voltage_now cat /sys/class/power_supply/battery/current_now");
                 BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream()));
                 fw = new FileWriter(file.getAbsoluteFile(), true);
                 bw = new BufferedWriter(fw);
 
-                bw.write(count);
+                bw.write(Integer.toString(count));
+
                 while( (s= bufferedReader.readLine())!=null ) {
-
-
-                    bw.write(" "+s + " ");
-
+                    if(isVolt) {volt=(Float.parseFloat(s))/1000000;System.out.println("voltage " + volt);isVolt=false;
+                        bw.write(" " + Double.toString(volt) + " ");
+                    }else{
+                        curr=(Float.parseFloat(s))/1000000;System.out.println("current "+ curr);isVolt=true;
+                        bw.write(" " + Double.toString(curr) + " ");
+                        power = volt*curr;
+                    }
                 }
+
+                System.out.println("Power " + power);
+                bw.write(" "+ Float.toString(power));
                 count++;
                 bw.newLine();
                 bw.close();

--- a/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/Cpu.java
+++ b/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/Cpu.java
@@ -1,8 +1,13 @@
 package com.example.xaradrim.benchmark_example.Tests;
 
+import android.app.Activity;
+import android.app.ActivityManager;
+import android.content.Context;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.List;
 import java.util.Random;
 import java.io.File;
 import java.io.FileReader;
@@ -10,36 +15,20 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
+
 /**
  * Created by xaradrim on 5/29/15.
  * * updated by pdp on 26-Jun
  */
-public class Cpu  implements Testable {
-    private boolean Testing;
+public class Cpu implements Testable {
 
-    // File
-    FileWriter fw;
-    BufferedWriter bw;
-    File file;
-    int count=0;
-    float volt=0,curr=0,power=0;
-    boolean isVolt = true;
-    Cpu(){
-        long unixTime = System.currentTimeMillis() / 1000L;
-        String fpath = "/sdcard/charsticks/" + "CPU-charLog"+".txt";
+   private boolean Testing;
 
 
-        file= new File(fpath);
-        // If file does not exists, then create it
-        try {
-            if (!file.exists()) {
-                file.createNewFile();
-            }
 
-        }
-        catch (IOException e){
-            System.out.println(e);
-        }
+
+    Cpu() {
+
     }
 
     @Override
@@ -51,57 +40,35 @@ public class Cpu  implements Testable {
         this.Testing = true;
 
 
-        while (this.isTesting()) {
-            number = r.nextInt(100000);
-            number++;
-            number += 2;
-            number -= 3;
-            number *= 7;
-            number /= 5;
-            System.out.println("The value in number for the cpu-> "+number+"\n");
-            String s = null;
-            try{
 
+            //repeated benchmark-test loop
+        System.out.println("runnning CPU loop");
+            while (this.isTesting()) {
+                number = r.nextInt(100000);
+                number++;
+                number += 2;
+                number -= 3;
+                number *= 7;
+                number /= 5;
 
-                Process process = Runtime.getRuntime().exec("cat /sys/class/power_supply/battery/voltage_now cat /sys/class/power_supply/battery/current_now");
-                BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream()));
-                fw = new FileWriter(file.getAbsoluteFile(), true);
-                bw = new BufferedWriter(fw);
+                //System.out.println("The value in number for the cpu-> " + number + "\n");
 
-                bw.write(Integer.toString(count));
-
-                while( (s= bufferedReader.readLine())!=null ) {
-                    if(isVolt) {volt=(Float.parseFloat(s))/1000000;System.out.println("voltage " + volt);isVolt=false;
-                        bw.write(" " + Double.toString(volt) + " ");
-                    }else{
-                        curr=(Float.parseFloat(s))/1000000;System.out.println("current "+ curr);isVolt=true;
-                        bw.write(" " + Double.toString(curr) + " ");
-                        power = volt*curr;
-                    }
-                }
-
-                System.out.println("Power " + power);
-                bw.write(" "+ Float.toString(power));
-                count++;
-                bw.newLine();
-                bw.close();
             }
-            catch (IOException e){
-                System.out.println(e);
-            }
-        }
+
     }
-
 
 
     @Override
     public void stop_test() {
+        this.Testing = false;
+        System.out.println("terminated...!");
 
-        this.Testing = false;System.out.println("terminated...!");
     }
 
     @Override
     public boolean isTesting() {
         return this.Testing;
     }
+
+
 }

--- a/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/Cpu.java
+++ b/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/Cpu.java
@@ -1,14 +1,47 @@
 package com.example.xaradrim.benchmark_example.Tests;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.Random;
-
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
 /**
  * Created by xaradrim on 5/29/15.
+ * updated by pdp on 26-Jun
  */
 public class Cpu  implements Testable {
     private boolean Testing;
 
+    // File initiators.
+    FileWriter fw;
+    BufferedWriter bw;
+    File file;
+    int count=0;
+    Cpu(){
 
+        //appending timestamp in the file name
+        long unixTime = System.currentTimeMillis() / 1000L;
+        //file save at this location
+        String fpath = "/sdcard/charsticks/" + "CPU-charLog" +unixTime+ ".txt";
+
+
+        file= new File(fpath);
+        // If file does not exists, then create it
+        try {
+            if (!file.exists()) {
+                file.createNewFile();
+            }
+
+        }
+        catch (IOException e){
+            System.out.println(e);
+        }
+    }
 
     @Override
     public void run() {
@@ -18,6 +51,7 @@ public class Cpu  implements Testable {
         Random r = new Random();
         this.Testing = true;
 
+
         while (this.isTesting()) {
             number = r.nextInt(100000);
             number++;
@@ -25,7 +59,30 @@ public class Cpu  implements Testable {
             number -= 3;
             number *= 7;
             number /= 5;
-            System.out.println("The value in number for the cpu : "+number+"\n");
+            System.out.println("The value in number for the cpu-> "+number+"\n");
+            String s = null;
+            try{
+
+                //running ADB commands; Writing to the file in /sdcard/
+                Process process = Runtime.getRuntime().exec("cat /sys/class/power_supply/battery/voltage_now cat /sys/class/power_supply/battery/current_now");
+                BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+                fw = new FileWriter(file.getAbsoluteFile(), true);
+                bw = new BufferedWriter(fw);
+
+                bw.write(count);
+                while( (s= bufferedReader.readLine())!=null ) {
+
+
+                    bw.write(" "+s + " ");
+
+                }
+                count++;
+                bw.newLine();
+                bw.close();
+            }
+            catch (IOException e){
+                System.out.println(e);
+            }
         }
     }
 
@@ -33,7 +90,8 @@ public class Cpu  implements Testable {
 
     @Override
     public void stop_test() {
-        this.Testing = false;
+
+        this.Testing = false;System.out.println("terminated...!");
     }
 
     @Override

--- a/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/Cpu.java
+++ b/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/Cpu.java
@@ -1,20 +1,8 @@
 package com.example.xaradrim.benchmark_example.Tests;
 
-import android.app.Activity;
-import android.app.ActivityManager;
-import android.content.Context;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.List;
 import java.util.Random;
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
+
 
 /**
  * Created by xaradrim on 5/29/15.
@@ -39,11 +27,12 @@ public class Cpu implements Testable {
         Random r = new Random();
         this.Testing = true;
 
+        //runing the CPu for specified time
 
 
             //repeated benchmark-test loop
         System.out.println("runnning CPU loop");
-            while (this.isTesting()) {
+            while (this.isTesting() ) {
                 number = r.nextInt(100000);
                 number++;
                 number += 2;

--- a/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/ObserveBench.java
+++ b/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/ObserveBench.java
@@ -1,0 +1,14 @@
+package com.example.xaradrim.benchmark_example.Tests;
+
+/**
+ * Created by larsip-ubuntu-2 on 6/26/15.
+ */
+public interface ObserveBench {
+
+    public void addObserver(TestObservers tObserve);
+
+    public void removeObserver(TestObservers tObserve);
+
+    public void notifyObserver();
+
+}

--- a/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/ObserveBench.java
+++ b/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/ObserveBench.java
@@ -1,14 +1,18 @@
 package com.example.xaradrim.benchmark_example.Tests;
 
 /**
- * Created by larsip-ubuntu-2 on 6/26/15.
+ * Created by Pardeep  on 6/26/15.
+ * provides interface to the Testobserves to register with type of test they want to get notified for.
  */
 public interface ObserveBench {
 
+    //add Testobservers to whom to send notifictaion
     public void addObserver(TestObservers tObserve);
 
+    //removes Testobservers
     public void removeObserver(TestObservers tObserve);
 
+    //notifies all the registered or added Test Observers.
     public void notifyObserver();
 
 }

--- a/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/ObserverCPU.java
+++ b/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/ObserverCPU.java
@@ -1,0 +1,123 @@
+package com.example.xaradrim.benchmark_example.Tests;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+
+/**
+ * Created by larsip-ubuntu-2 on 6/26/15.
+ */
+public class ObserverCPU implements TestObservers {
+    private ObserveBench ob1;
+    private String funName = null;
+
+    // File intiator
+    FileWriter fw;
+    BufferedWriter bw;
+    File file;
+
+
+    int count = 0;
+    float volt = 0, curr = 0, power = 0;
+    String s = null;
+    boolean isVolt = true;
+
+
+    //update coming from CPU
+    private String testType = null;
+    private boolean testStarted = false, testStopped = false;
+
+
+    public ObserverCPU(ObserveBench ob1, String name) {
+        this.ob1 = ob1;
+        this.funName = name;
+        this.ob1.addObserver(this);
+
+        long unixTime = System.currentTimeMillis() / 1000L; //to create unique file everytime test runs *not used right now
+        String fpath = "/sdcard/charsticks/" + "CPU-charLog" + ".txt";
+        file = new File(fpath);
+        // If file does not exists, then create it
+        try {
+            if (!file.exists()) {
+                file.createNewFile();
+            }
+        } catch (IOException e) {
+            System.out.println(e);
+        }
+
+    }
+
+    @Override
+    public void update(String testType, boolean testStarted, boolean testStopped) {
+        this.testType = testType;
+        this.testStarted = testStarted;
+        this.testStopped = testStopped;
+
+
+        //while (this.testType.equalsIgnoreCase("cpu") && this.testStarted) {
+        while (this.testStarted) {
+
+            startObservation();
+            //this.testType = testType;
+            this.testStarted = testStarted;
+
+        }
+
+    }
+
+    private void startObservation() {
+
+        try {
+            fw = new FileWriter(file.getAbsoluteFile(), true);
+            bw = new BufferedWriter(fw);
+
+
+            //running ADB command lines
+            Process process = Runtime.getRuntime().exec("cat /sys/class/power_supply/battery/voltage_now cat /sys/class/power_supply/battery/current_now");
+            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+
+            //reading and writing output to file
+            bw.write(Integer.toString(count));
+
+            while ((s = bufferedReader.readLine()) != null) {
+
+                //extracting voltage and current
+                if (isVolt) {
+                    volt = (Float.parseFloat(s)) / 1000000;
+                    //System.out.println("voltage " + volt);
+                    isVolt = false;
+
+                    bw.write(" " + Double.toString(volt) + " ");
+                } else {
+                    curr = (Float.parseFloat(s)) / 1000000;
+                    //System.out.println("current " + curr);
+                    isVolt = true;
+
+                    bw.write(" " + Double.toString(curr) + " ");
+
+                    power = volt * curr;
+                }
+            }
+            //getting power and writing to the file
+            System.out.println("Power consumed " + power);
+
+            bw.write(" " + Float.toString(power));
+            count++;
+            bw.newLine();
+
+
+            bw.close();
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+    }
+
+
+}
+

--- a/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/ObserverCPU.java
+++ b/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/ObserverCPU.java
@@ -9,7 +9,9 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 
 /**
- * Created by larsip-ubuntu-2 on 6/26/15.
+ * Created by Pardeep on 6/26/15.
+ * Example CPU-observer for our CPU-benchmark
+ *
  */
 public class ObserverCPU implements TestObservers , Runnable{
     private ObserveBench ob1;
@@ -31,8 +33,10 @@ public class ObserverCPU implements TestObservers , Runnable{
     private String testType = null;
     private boolean testStarted = false, testStopped = false;
 
+    //To run writing process as a thread. concurently to the benchmark
     Thread t;
     boolean threadRunning = false;
+
     public ObserverCPU(ObserveBench ob1, String name) {
         this.ob1 = ob1;
         this.funName = name;
@@ -41,8 +45,8 @@ public class ObserverCPU implements TestObservers , Runnable{
         long unixTime = System.currentTimeMillis() / 1000L; //to create unique file everytime test runs *not used right now
         String fpath = "/sdcard/charsticks/" + "CPU-charLog" + ".txt";
         file = new File(fpath);
-        // If file does not exists, then create it
 
+        // If file does not exists, then create it
         try {
             if (!file.exists()) {
                 file.createNewFile();
@@ -58,7 +62,6 @@ public class ObserverCPU implements TestObservers , Runnable{
         this.testType = testType;
         this.testStarted = testStarted;
         this.testStopped = testStopped;
-
 
         //while (this.testType.equalsIgnoreCase("cpu") && this.testStarted) {
       if (this.testType.equalsIgnoreCase("cpu") && this.testStarted && !(this.threadRunning)) {

--- a/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/ObserverCPU.java
+++ b/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/ObserverCPU.java
@@ -59,13 +59,14 @@ public class ObserverCPU implements TestObservers {
 
 
         //while (this.testType.equalsIgnoreCase("cpu") && this.testStarted) {
-        while (this.testStarted) {
-
-            startObservation();
-            //this.testType = testType;
-            this.testStarted = testStarted;
-
-        }
+//        while (this.testStarted) {
+//
+//           // startObservation();
+//            //this.testType = testType;
+//            this.testStarted = testStarted;
+//            System.out.println("Writing data...");
+//
+//        }
 
     }
 
@@ -103,7 +104,7 @@ public class ObserverCPU implements TestObservers {
                 }
             }
             //getting power and writing to the file
-            System.out.println("Power consumed " + power);
+            //System.out.println("Power consumed " + power);
 
             bw.write(" " + Float.toString(power));
             count++;

--- a/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/ObserverCPU.java
+++ b/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/ObserverCPU.java
@@ -11,9 +11,8 @@ import java.util.ArrayList;
 /**
  * Created by Pardeep on 6/26/15.
  * Example CPU-observer for our CPU-benchmark
- *
  */
-public class ObserverCPU implements TestObservers , Runnable{
+public class ObserverCPU implements TestObservers, Runnable {
     private ObserveBench ob1;
     private String funName = null;
 
@@ -54,7 +53,7 @@ public class ObserverCPU implements TestObservers , Runnable{
         } catch (IOException e) {
             System.out.println(e);
         }
-        t = new Thread(this, "CPU_ObserverThread");
+
     }
 
     @Override
@@ -62,76 +61,74 @@ public class ObserverCPU implements TestObservers , Runnable{
         this.testType = testType;
         this.testStarted = testStarted;
         this.testStopped = testStopped;
-
-        //while (this.testType.equalsIgnoreCase("cpu") && this.testStarted) {
-      if (this.testType.equalsIgnoreCase("cpu") && this.testStarted && !(this.threadRunning)) {
-//
-//           // startObservation();
-//            //this.testType = testType;
-//            this.testStarted = testStarted;
-           System.out.println("Writing data...");
-          threadRunning = true;
+        if (this.testType.equalsIgnoreCase("cpu") && this.testStarted && !(this.threadRunning)) {
+            t = new Thread(this, "CPU_ObserverThread");
             t.start();
+            System.out.println("thread running");
+            this.threadRunning = true;
         }
-        if(this.testStopped && this.threadRunning){
+
+        if (this.testStopped && this.threadRunning) {
             try {
                 t.join();
                 System.out.println("Cpu observer Thread stopped");
-                threadRunning = false;
-            } catch (InterruptedException e) {
+                this.threadRunning = false;
+                this.testStarted = false;
+            } catch (Exception e) {
                 e.printStackTrace();
             }
         }
+
 
     }
 
     private void startObservation() {
 
-            try {
-                fw = new FileWriter(file.getAbsoluteFile(), true);
-                bw = new BufferedWriter(fw);
+        try {
+            fw = new FileWriter(file.getAbsoluteFile(), true);
+            bw = new BufferedWriter(fw);
 
 
-                //running ADB command lines
-                Process process = Runtime.getRuntime().exec("cat /sys/class/power_supply/battery/voltage_now cat /sys/class/power_supply/battery/current_now");
-                BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+            //running ADB command lines
+            Process process = Runtime.getRuntime().exec("cat /sys/class/power_supply/battery/voltage_now cat /sys/class/power_supply/battery/current_now");
+            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream()));
 
-                //reading and writing output to file
-                bw.write(Integer.toString(count));
+            //reading and writing output to file
+            bw.write(Integer.toString(count));
 
-                while ((s = bufferedReader.readLine()) != null) {
+            while ((s = bufferedReader.readLine()) != null) {
 
-                    //extracting voltage and current
-                    if (isVolt) {
-                        volt = (Float.parseFloat(s)) / 1000000;
-                        //System.out.println("voltage " + volt);
-                        isVolt = false;
+                //extracting voltage and current
+                if (isVolt) {
+                    volt = (Float.parseFloat(s)) / 1000000;
+                    //System.out.println("voltage " + volt);
+                    isVolt = false;
 
-                        bw.write(" " + Double.toString(volt) + " ");
-                    } else {
-                        curr = (Float.parseFloat(s)) / 1000000;
-                        //System.out.println("current " + curr);
-                        isVolt = true;
+                    bw.write(" " + Double.toString(volt) + " ");
+                } else {
+                    curr = (Float.parseFloat(s)) / 1000000;
+                    //System.out.println("current " + curr);
+                    isVolt = true;
 
-                        bw.write(" " + Double.toString(curr) + " ");
+                    bw.write(" " + Double.toString(curr) + " ");
 
-                        power = volt * curr;
-                    }
+                    power = volt * curr;
                 }
-                //getting power and writing to the file
-                System.out.println("Power consumed " + power);
-
-                bw.write(" " + Float.toString(power));
-                count++;
-                bw.newLine();
-
-
-                bw.close();
-
-            } catch (IOException e) {
-                System.out.println("IOException occured..");
-                e.printStackTrace();
             }
+            //getting power and writing to the file
+            System.out.println("Power consumed " + power);
+
+            bw.write(" " + Float.toString(power));
+            count++;
+            bw.newLine();
+
+
+            bw.close();
+
+        } catch (IOException e) {
+            System.out.println("IOException occured..");
+            e.printStackTrace();
+        }
 
 
     }
@@ -139,8 +136,9 @@ public class ObserverCPU implements TestObservers , Runnable{
 
     @Override
     public void run() {
+        System.out.println("Caching data for writing.." + this.testStarted);
         while (this.testStarted) {
-            System.out.println("Caching data for writing..");
+            System.out.println("o.O");
             startObservation();
         }
 

--- a/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/Test.java
+++ b/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/Test.java
@@ -58,7 +58,8 @@ public class Test implements ObserveBench{
 
         for (Thread t : this.bufferContainer){
             t.start();
-            testStarted=true;testStopped=false;
+            testStarted=true;
+            testStopped=false;
             System.out.println("started");
             notifyObserver();
         }
@@ -68,7 +69,8 @@ public class Test implements ObserveBench{
         if (this.testContainer.isEmpty()) return ;
 
         for (Testable t : this.testContainer){
-            t.stop_test();testStarted=false;
+            t.stop_test();
+            testStarted=false;
             testStopped=true;
         }
         notifyObserver();
@@ -99,7 +101,7 @@ public class Test implements ObserveBench{
     public void notifyObserver() {
         System.out.println("notified ..");
         for(TestObservers to: this.tObserve){
-            to.update(testType,testStarted, testStopped);
+            to.update(this.testType,this.testStarted, this.testStopped);
         }
 
     }

--- a/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/Test.java
+++ b/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/Test.java
@@ -5,16 +5,19 @@ import java.util.ArrayList;
 /**
  * Created by xaradrim on 5/30/15.
  */
-public class Test {
+public class Test implements ObserveBench{
 
     private ArrayList<Testable> testContainer;
     private ArrayList<Thread> bufferContainer;
-
+    private ArrayList<TestObservers> tObserve ;
+    private String testType = null;
+    private boolean testStarted = false,testStopped = true;
     public Test(){
         testContainer = new ArrayList<Testable>();
         bufferContainer = new ArrayList<Thread>();
+        tObserve = new ArrayList<TestObservers>();
     }
-
+    //
     /**
      * make a tester based on the param string option
      * and return the tester object for it.
@@ -30,6 +33,7 @@ public class Test {
      *
      */
     public Testable make_test(String param){
+        testType = param;
         param = param.toLowerCase();
 
         switch (param){
@@ -49,21 +53,25 @@ public class Test {
     }
 
     public void start_test(){
-
+        notifyObserver();
         if (this.bufferContainer.isEmpty()) return ;
 
         for (Thread t : this.bufferContainer){
             t.start();
+            testStarted=true;testStopped=false;
+            System.out.println("started");
+            notifyObserver();
         }
     }
     public void halt_execution(){
-
+        notifyObserver();
         if (this.testContainer.isEmpty()) return ;
 
         for (Testable t : this.testContainer){
-            t.stop_test();
+            t.stop_test();testStarted=false;
+            testStopped=true;
         }
-
+        notifyObserver();
         this.testContainer.clear();
         this.bufferContainer.clear();
     }
@@ -71,6 +79,28 @@ public class Test {
      * To be implemented =D
      */
     public void logTest(){
+
+    }
+
+    @Override
+    public void addObserver(TestObservers to) {
+        System.out.println("observer added in test class");
+        this.tObserve.add(to);
+
+    }
+
+    @Override
+    public void removeObserver(TestObservers to) {
+        int index = this.tObserve.indexOf(tObserve);
+        this.tObserve.remove(index);
+    }
+
+    @Override
+    public void notifyObserver() {
+        System.out.println("notified ..");
+        for(TestObservers to: this.tObserve){
+            to.update(testType,testStarted, testStopped);
+        }
 
     }
 }

--- a/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/TestObservers.java
+++ b/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/TestObservers.java
@@ -1,8 +1,11 @@
 package com.example.xaradrim.benchmark_example.Tests;
 
 /**
- * Created by larsip-ubuntu-2 on 6/26/15.
+ * Created by Pardeep  on 6/26/15.
+ * This interface is for intended observers who are observing the runnning benchamrks
  */
 public interface TestObservers {
+
+    //Observers will recive updates/notification from form benchmarks through this method
     public void update(String testType, boolean testStarted, boolean testStopped);
 }

--- a/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/TestObservers.java
+++ b/app/src/main/java/com/example/xaradrim/benchmark_example/Tests/TestObservers.java
@@ -1,0 +1,8 @@
+package com.example.xaradrim.benchmark_example.Tests;
+
+/**
+ * Created by larsip-ubuntu-2 on 6/26/15.
+ */
+public interface TestObservers {
+    public void update(String testType, boolean testStarted, boolean testStopped);
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -50,4 +50,5 @@
         android:layout_alignLeft="@+id/textView2"
         android:layout_alignStart="@+id/textView2" />
 
+
 </RelativeLayout>


### PR DESCRIPTION
- Have added the model for capturing the power measurements while benchmark is running (specifically CPU and for Project ARA app)
- Idea was to run another (ObserveCPU) thread concurrent to benchmark while providing the notifications and updates from test class to this thread and controlling its execution.
- We will still get the measurements written to the file inside folder "charsticks" in /sdcard/ (still missing logic for creating or using the previously created folder).

Any suggestion or pointers to further enhance the model (to observe benchmark and get the data independently) or any part of the code is 
